### PR TITLE
Track Terragrunt version

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,12 +1,11 @@
-FROM hashicorp/terraform:VERSION
+FROM hashicorp/terraform:TERRAFORM_VERSION
 
-ARG TERRAGRUNT
+ARG TERRAGRUNT_VERSION
 
 RUN apk add --update --no-cache bash git openssh
 
-ADD https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT}/terragrunt_linux_amd64 /usr/local/bin/terragrunt
-
-RUN chmod +x /usr/local/bin/terragrunt
+RUN wget https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 -O /usr/local/bin/terragrunt && \
+    chmod +x /usr/local/bin/terragrunt
 
 WORKDIR /apps
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # enhanced tool to manage terraform deployment with terragrunt
 
-Auto-trigger docker build for [terragrunt](https://github.com/gruntwork-io/terragrunt) when new terraform version is related.
+Auto-trigger docker build for [terragrunt](https://github.com/gruntwork-io/terragrunt) when new terraform or terragrunt version is released.
 
 [![DockerHub Badge](http://dockeri.co/image/alpine/terragrunt)](https://hub.docker.com/r/alpine/terragrunt/)
 
 ### Tools included in this container
 
-* [terraform](https://terraform.io) - terraform version is this docker image's tag
-* [terragrunt](https://github.com/gruntwork-io/terragrunt) - latest terragrunt version when run the build
+* [terraform](https://terraform.io) - latest terraform version at time of build
+* [terragrunt](https://github.com/gruntwork-io/terragrunt) -latest terragrunt version at time of build
 
 ### Repo:
 
@@ -17,7 +17,9 @@ https://github.com/alpine-docker/terragrunt
 
 https://travis-ci.org/alpine-docker/terragrunt
 
-### Docker iamge tags:
+### Docker image tags:
+
+The tag will be a combination of the terragrunt and terraform versions. The version for terragrunt will be listed first, followed by a -tf and the version of terraform included.  This enables updated releases when either terraform or terragrunt release new updates. 
 
 https://hub.docker.com/r/alpine/terragrunt/tags/
 
@@ -42,8 +44,11 @@ https://hub.docker.com/r/alpine/terragrunt/tags/
 
 # The Processes to build this image
 
-* Enable Travis CI cronjob on this repo to run build daily on master branch
-* Check if there are new tags/releases announced via Github REST API
-* Match the exist docker image tags via Hub.docker.io REST API
-* If not matched, build the image with latest `terraform version` as tag and push to hub.docker.com
-* Always install latest version of terragrunt
+Enable Travis CI cronjob on this repo to run build daily on master branch
+
+The build.sh will:
+* Check the latest version of Terraform via GitHub REST API
+* Check the latest version of Terragrunt via GitHub REST API
+* Generate the expected tag for the Alpine Terragrunt version
+* Check the existing Alpine Terragrunt tags via dockerhub REST API
+* If the expected tag does not exist in dockerhub, build the image with the expected tag and latest and push to [hub.docker.com](https://hub.docker.com/r/alpine/terragrunt/tags/)

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ if [[ ( $sum -ne 1 ) || ( ${REBUILD} == "true" ) ]];then
   docker build --build-arg TERRAGRUNT=${terragrunt} --no-cache -t ${image}:${latest} .
   docker tag ${image}:${latest} ${image}:latest
 
-  if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+  if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == false ]]; then
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
     docker push ${image}:${latest}
     docker push ${image}:latest

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,8 @@
 set -ex
 
 image="alpine/terragrunt"
-repo="hashicorp/terraform"
+terraform_repo="hashicorp/terraform"
+terragrunt_repo="gruntwork-io/terragrunt"
 
 if [[ ${CI} == 'true' ]]; then
   CURL="curl -sL -H \"Authorization: token ${API_TOKEN}\""
@@ -17,30 +18,35 @@ else
   CURL="curl -sL"
 fi
 
-latest=$(${CURL} https://api.github.com/repos/${repo}/releases/latest |jq -r .tag_name|sed 's/v//')
+latest_terraform=$(${CURL} https://api.github.com/repos/${terraform_repo}/releases/latest |jq -r .tag_name|sed 's/v//')
 
-terragrunt=$(${CURL} https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest |jq -r .tag_name)
+latest_terragrunt=$(${CURL} https://api.github.com/repos/${terragrunt_repo}/releases/latest |jq -r .tag_name)
+
+# Define tag for Alpine Terragrunt releases
+latest_alpine_terragrunt=${latest_terragrunt}-tf${latest_terraform}
 
 sum=0
-echo "Lastest release is: ${latest}"
+echo "Latest Terraform release is: ${latest_terraform}"
+echo "Latest Terragrunt release is: ${latest_terragrunt}"
+echo "Latest Alpine Terragrunt tag is: ${latest_alpine_terragrunt}"
 
 tags=`curl -s https://hub.docker.com/v2/repositories/${image}/tags/ |jq -r .results[].name`
 
 for tag in ${tags}
 do
-  if [ ${tag} == ${latest} ];then
+  if [ ${tag} == ${latest_alpine_terragrunt} ];then
     sum=$((sum+1))
   fi
 done
 
 if [[ ( $sum -ne 1 ) || ( ${REBUILD} == "true" ) ]];then
-  sed "s/VERSION/${latest}/" Dockerfile.template > Dockerfile
-  docker build --build-arg TERRAGRUNT=${terragrunt} --no-cache -t ${image}:${latest} .
-  docker tag ${image}:${latest} ${image}:latest
+  sed "s/TERRAFORM_VERSION/${latest_terraform}/" Dockerfile.template > Dockerfile
+  docker build --build-arg TERRAGRUNT_VERSION=${latest_terragrunt} --build-arg TERRAFORM_VERSION=${latest_terraform} --no-cache -t ${image}:${latest_alpine_terragrunt} .
+  docker tag ${image}:${latest_alpine_terragrunt} ${image}:latest
 
   if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == false ]]; then
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
-    docker push ${image}:${latest}
+    docker push ${image}:${latest_alpine_terragrunt}
     docker push ${image}:latest
   fi
 


### PR DESCRIPTION
With the current tag reflecting the terraform version, there have been
no updates to inclue newer versions of terragrunt.

This change clarifies where terragrunt vs terraform version is used.
It also uses a combined tag so that new builds will be generated when a
new version of Terraform or Terragrunt are released.