### PR TITLE
Trigger rebuild if Terragrunt has released a newer version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,17 @@ do
   fi
 done
 
+# Example value: 2020-11-06T18:05:06Z
+terragrunt_published_date=$(${CURL} https://api.github.com/repos/gruntwork-io/terragrunt/releases/latest | jq -r '.published_at')
+
+# Example value: 2020-10-22T16:01:28.23617Z
+image_published_date=$(${CURL} https://hub.docker.com/v2/repositories/${image}/tags/ | jq -r '.results[] | select(.name=="latest") | .tag_last_pushed')
+
+# If Terragrunt has a newer published date, then we have to force a build
+if [ $(date -d ${terragrunt_published_date} +%s) -gt $(date -d ${image_published_date} +%s) ]; then
+  REBUILD="true"
+fi
+
 if [[ ( $sum -ne 1 ) || ( ${REBUILD} == "true" ) ]];then
   sed "s/VERSION/${latest}/" Dockerfile.template > Dockerfile
   docker build --build-arg TERRAGRUNT=${terragrunt} --no-cache -t ${image}:${latest} .


### PR DESCRIPTION
This PR forces a rebuild of the image if Terragrunt has released a newer version on a date after the pushed date of the `latest` tag.

For example, right now Terragrunt released `v0.26.2` but `alpine/terragrunt:latest` has Terragrunt version `v0.25.4`.

This should fix #4 and have an alternative solution to #5.

Let me know what do you think.

Thanks!