### PR TITLE
Reorganise tags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ function get_image_tags() {
 }
 
 function build_docker_image() {
-  local tag="${1}"
+  local terraform="${1}"
   local terragrunt="${2}"
   local image_name="${3}"
   
@@ -52,7 +52,9 @@ function build_docker_image() {
      --build-arg TERRAGRUNT="${terragrunt}" \
      --no-cache \
      --push \
-     --tag "${image_name}:${tag}" \
+     --tag "${image_name}:tf${terraform}" \
+     --tag "${image_name}:${terragrunt}" \
+     --tag "${image_name}:${terragrunt}-tf${terraform}" \
      --tag "${image_name}:latest" \
      .
   fi


### PR DESCRIPTION
This updates the build process to build 4 tags with the same content:

* `latest` - latest version
* `<terragrunt>` - e.g. `0.52.5` - based on the Terragrunt version
* `tf<terraform>` - e.g. `tf1.6.2` - based on the Terraform version
* `<terragrunt>-tf<terraform>` - e.g. `0.52.5-tf1.6.2` - based on both the Terraform and Terragrunt versions

This is to provide better visibility of the versions in the container image and also so that people can pin this to a version they know is compatible with their configuration.

Closes #26.

