### PR TITLE
fix: adjust trivy db source to public ecr mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,8 @@ jobs:
           trivy image --format table --exit-code 1 \
              --ignore-unfixed --vuln-type os,library \
              --scanners vuln --severity CRITICAL,HIGH \
-             --timeout 10m0s alpine/terragrunt
+             --timeout 10m0s alpine/terragrunt \
+             --db-repository public.ecr.aws/aquasecurity/trivy-db
 
 workflows:
   build:


### PR DESCRIPTION
Adjusts Trivy config options to use public ECR mirror.

Closes #40 