### PR TITLE
Bump GitHub runner to versions using Node24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Step to fetch the latest curl version
       - name: Get latest tool versions
@@ -53,7 +53,7 @@ jobs:
 
       # Authenticate to the container registry
       - name: Authenticate to registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -62,7 +62,7 @@ jobs:
       # Extract metadata (tags, labels) for Docker
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |
@@ -76,7 +76,7 @@ jobs:
       # (don't push on PR, load instead)
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           sbom: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout `keepalive` branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: keepalive  # Checkout that specific branch
 


### PR DESCRIPTION
Fixes #48 

This PR bumps multiple GitHub Runner to versions using Node24 as default runtime

* from actions/checkout@v4 to actions/checkout@v6
* from docker/build-push-action@v6 to docker/build-push-action@v7
* from docker/login-action@v3 to docker/login-action@v4
* from docker/metadata-action@v5 to docker/metadata-action@v6
* from docker/setup-buildx-action@v3 to docker/setup-buildx-action@v4
